### PR TITLE
fix(deps): pin setuptools <81 to avoid pkg_resources removal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,10 @@ optional-dependencies.test = { file = ["requirements/test_requirements.txt"] }
 
 [tool.setuptools.packages.find]
 include = ["tts_plugin_mozilla_remote*"]
+
+[tool.uv]
+# Pin setuptools below 81 — 81 removed --dry-run, 82 removed pkg_resources
+# entirely. The setuptools high-sev advisory (PackageIndex.download path
+# traversal) is build-time only via easy_install which we don't invoke.
+# Revisit once the OVOS dep chain confirms importlib.metadata-only paths.
+constraint-dependencies = ["setuptools<81"]

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 
+[manifest]
+constraints = [{ name = "setuptools", specifier = "<81" }]
+
 [[package]]
 name = "audioop-lts"
 version = "0.2.2"
@@ -1329,11 +1332,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Follow-up to #12 (already merged). Adds `setuptools<81` constraint to the uv lock so we don't accidentally roll forward into setuptools 82 which removed `pkg_resources` entirely.

## Why

The setuptools high-sev advisory (PackageIndex.download path traversal in easy_install) that #12 tried to patch is **build-time only** — we don't invoke easy_install. Meanwhile:
- setuptools 81.0.0 removed `--dry-run`
- setuptools 82.0.0 **removed `pkg_resources` entirely**

`ovos-plugin-manager.utils` has an `importlib.metadata` primary path with `pkg_resources` fallback. The fallback is dead code on Python 3.10+, but the broader OVOS dep chain hasn't been audited for direct `pkg_resources` imports. The runtime risk of breaking plugin discovery outweighs a build-time-only advisory.

setuptools 82.0.1 → 80.10.2.

## Test plan

- [x] `uv run pytest` — 7/7 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)